### PR TITLE
Changed README image reference to local reference/ helps repo portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Check out various DPRG line following courses at https://github.com/dprg/Contest
 Shown below is an image of the DPRG Challenge Course. Join in and create your controller to solve this course! 
 <p>
   
-![](https://github.com/ron-grant/LineFollowerSimLib/blob/master/ChallengeSmallImage.jpg)
+![](ChallengeSmallImage.jpg)
 
 
 


### PR DESCRIPTION
Noted that original README failed to render correctly on a local copy of the repo - due to absolute http reference to github blob.  This fix points README to the local file system.